### PR TITLE
Доработана функциональность по ТЗ Спринта 6

### DIFF
--- a/Test/InMemoryHistoryManagerTest.java
+++ b/Test/InMemoryHistoryManagerTest.java
@@ -1,10 +1,11 @@
+import com.yandex.app.model.Epic;
+import com.yandex.app.model.Subtask;
 import com.yandex.app.model.Task;
 import com.yandex.app.model.TaskStatus;
 import com.yandex.app.service.InMemoryHistoryManager;
+import com.yandex.app.service.Node;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -21,11 +22,12 @@ class InMemoryHistoryManagerTest {
 
     @Test
     void add() {
-        List<Task> history = historyManager.getHistory();
-        assertNotNull(history, "После добавления задачи, история не должна быть пустой.");
-        assertEquals(1, history.size(), "После добавления задачи, история не должна быть пустой.");
+        Node<Task> head = historyManager.head;
+        assertNotNull(head, "После добавления задачи, история не должна быть пустой.");
+        assertEquals(1, historyManager.getHistory().size(), "После добавления задачи, история не " +
+                "должна быть пустой.");
 
-        Task savedTask = (Task) history.get(0);
+        Task savedTask = head.task;
         assertEquals("name", savedTask.getNameOfTask());
         assertEquals("description", savedTask.getDescriptionOfTask());
         assertEquals(1, savedTask.getId());
@@ -33,21 +35,72 @@ class InMemoryHistoryManagerTest {
 
         task.setStatus(TaskStatus.DONE);
         historyManager.add(task);
-        assertEquals(TaskStatus.NEW, savedTask.getStatus());
-        assertEquals(2, history.size(), "При обновлении задачи, в истории должны быть обе задачи");
+        assertEquals(TaskStatus.DONE, savedTask.getStatus());
+        assertEquals(1, historyManager.getHistory().size(), "При обновлении задачи с тем же ID, " +
+                "размер истории не должен увеличиваться");
     }
 
     @Test
-    void saveOldTask() {
-        List<Task> history = historyManager.getHistory();
-        assertNotNull(history, "После добавления задачи, история не должна быть пустой.");
+    void saveNewTask() {
+        assertEquals(1, historyManager.getHistory().size(), "После добавления задачи, история не " +
+                "должна быть пустой.");
         Task task2 = new Task("name2", "description2", 1, TaskStatus.NEW);
         historyManager.add(task2);
-        assertEquals(2, history.size(), "При добавлении следующей задачи, старая остаётся");
+
+        assertEquals(1, historyManager.getHistory().size(), "При добавлении следующей задачи " +
+                "с тем же ID, размер истории не изменяется");
     }
 
-   @Test
-   void checkHistory() {
+    @Test
+    void deleteTask() {
+        historyManager.remove(1);
+        assertEquals(0, historyManager.getHistory().size(), "После удаления задачи, история должна " +
+                "быть пуста");
+    }
 
-   }
+    @Test
+    void removedTasksDoNotKeepOldIds() {
+        assertTrue(historyManager.getHistory().contains(task));
+        historyManager.remove(task.getId());
+        assertFalse(historyManager.getHistory().contains(task));
+        Task newTask = new Task("newName", "newDescription", 1, TaskStatus.NEW);
+        historyManager.add(newTask);
+        assertTrue(historyManager.getHistory().contains(newTask));
+    }
+
+    @Test
+    void removedSubtaskDoNotKeepOldIds() {
+        Epic epic = new Epic("nameEpic", "descriptionEpic", 2, TaskStatus.NEW);
+        historyManager.add(epic);
+        Subtask subtask = new Subtask("name", "description", 3, TaskStatus.NEW, epic);
+        historyManager.add(subtask);
+        assertTrue(historyManager.getHistory().contains(subtask));
+
+        historyManager.remove(subtask.getId());
+        assertFalse(historyManager.getHistory().contains(subtask), "Подзадача должна быть удалена из эпика");
+
+        Subtask newSubtask = new Subtask("newName", "newDescription", 3, TaskStatus.NEW,
+                epic);
+        historyManager.add(newSubtask);
+        assertTrue(historyManager.getHistory().contains(newSubtask));
+    }
+
+    @Test
+    void changeFieldsBySetters() {
+        Epic epic = new Epic("nameEpic", "descriptionEpic", 2, TaskStatus.NEW);
+        historyManager.add(epic);
+        Subtask subtask = new Subtask("name", "description", 3, TaskStatus.NEW, epic);
+        historyManager.add(subtask);
+
+        assertEquals("name", subtask.getNameOfTask());
+        assertEquals(TaskStatus.NEW, subtask.getStatus());
+
+        subtask.setNameOfTask("newName");
+        subtask.setStatus(TaskStatus.DONE);
+
+        historyManager.add(subtask);
+        assertNotNull(subtask);
+        assertEquals("newName", subtask.getNameOfTask());
+        assertEquals(TaskStatus.DONE, subtask.getStatus());
+    }
 }

--- a/src/com/yandex/app/Main.java
+++ b/src/com/yandex/app/Main.java
@@ -1,7 +1,6 @@
 package com.yandex.app;
 
 import com.yandex.app.model.Epic;
-import com.yandex.app.model.Subtask;
 import com.yandex.app.model.Task;
 import com.yandex.app.model.TaskStatus;
 import com.yandex.app.service.InMemoryTaskManager;
@@ -24,7 +23,9 @@ public class Main {
         inMemoryTaskManager.updateSubtaskStatus(4, TaskStatus.IN_PROGRESS);
         inMemoryTaskManager.updateSubtaskStatus(5, TaskStatus.IN_PROGRESS);
         inMemoryTaskManager.getEpicById(3);
+        inMemoryTaskManager.getSubtaskById(4);
         inMemoryTaskManager.getAllSubtasks(3);
+        inMemoryTaskManager.getEpicById(3);
         List<Task> history = inMemoryTaskManager.historyManager.getHistory();
         for (Object histories : history) {
             System.out.println(histories);

--- a/src/com/yandex/app/model/Epic.java
+++ b/src/com/yandex/app/model/Epic.java
@@ -32,4 +32,10 @@ public class Epic extends Task {
     public Epic copy() {
         return new Epic(getNameOfTask(), getDescriptionOfTask(), getId(), getStatus());
     }
+
+    @Override
+    public String toString() {
+        return "Epic [id=" + getId() + ", name=" + getNameOfTask() + ", description=" + getDescriptionOfTask() + ", " +
+                "status=" + getStatus() + "]";
+    }
 }

--- a/src/com/yandex/app/model/Subtask.java
+++ b/src/com/yandex/app/model/Subtask.java
@@ -33,4 +33,10 @@ public class Subtask extends Task {
     public Subtask copy() {
         return new Subtask(getNameOfTask(), getDescriptionOfTask(), getId(), getStatus(), epic);
     }
+
+    @Override
+    public String toString() {
+        return "Subtask [id=" + getId() + ", name=" + getNameOfTask() + ", description=" + getDescriptionOfTask() +
+                ", status=" + getStatus() + ", epic=" + epic + "]";
+    }
 }

--- a/src/com/yandex/app/model/Task.java
+++ b/src/com/yandex/app/model/Task.java
@@ -12,7 +12,7 @@ public class Task {
         return nameOfTask;
     }
 
-    public String setNameOfTask (String nameOfTask){
+    public String setNameOfTask(String nameOfTask) {
         this.nameOfTask = nameOfTask;
         return nameOfTask;
     }
@@ -56,5 +56,11 @@ public class Task {
 
     public Task copy() {
         return new Task(nameOfTask, descriptionOfTask, id, status);
+    }
+
+    @Override
+    public String toString() {
+        return "Task [id=" + id + ", name=" + nameOfTask + ", description=" + descriptionOfTask + ", status=" +
+                status + "]";
     }
 }

--- a/src/com/yandex/app/service/HistoryManager.java
+++ b/src/com/yandex/app/service/HistoryManager.java
@@ -8,4 +8,6 @@ public interface HistoryManager {
     void add(Task task);
 
     List<Task> getHistory();
+
+    void remove(int id);
 }

--- a/src/com/yandex/app/service/InMemoryHistoryManager.java
+++ b/src/com/yandex/app/service/InMemoryHistoryManager.java
@@ -2,23 +2,79 @@ package com.yandex.app.service;
 
 import com.yandex.app.model.Task;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Map;
 
 public class InMemoryHistoryManager implements HistoryManager {
 
-    private List<Task> history = new ArrayList<>();
+    public Node<Task> head;
+    protected Node<Task> tail;
+    private final Map<Integer, Node> idToNode = new HashMap<>();
 
     @Override
     public void add(Task task) {
-        history.add(task.copy());
-        if (history.size() > 10) {
-            history.remove(0);
+        if (idToNode.containsKey(task.getId())) {
+            removeNode(idToNode.get(task.getId()));
         }
+        idToNode.put(task.getId(), linkLast(task));
     }
 
     @Override
     public List<Task> getHistory() {
-        return List.copyOf(history);
+        return getTasks();
+    }
+
+    @Override
+    public void remove(int id) {
+        if (idToNode.containsKey(id)) {
+            removeNode(idToNode.get(id));
+            idToNode.remove(id);
+        }
+    }
+
+    private Node<Task> linkLast(Task task) {
+        final Node<Task> oldTail = tail;
+        final Node<Task> newNode = new Node<>(oldTail, task, null);
+        tail = newNode;
+        if (oldTail == null) {
+            head = newNode;
+        } else {
+            oldTail.next = newNode;
+        }
+        return newNode;
+    }
+
+    private List<Task> getTasks() {
+        List<Task> listTasks = new ArrayList<>();
+        Node<Task> current = head;
+        while (current != null) {
+            listTasks.add(current.task);
+            current = current.next;
+        }
+        return listTasks;
+    }
+
+    private void removeNode(Node<Task> nodeToRemove) {
+        if (nodeToRemove == head) {
+            head = head.next;
+            if (head != null) {
+                head.prev = null;
+            } else {
+                tail = null;
+            }
+        } else if (nodeToRemove == tail) {
+            tail = tail.prev;
+            if (tail != null) {
+                tail.next = null;
+            } else {
+                head = null;
+            }
+        } else {
+            nodeToRemove.prev.next = nodeToRemove.next;
+            nodeToRemove.next.prev = nodeToRemove.prev;
+        }
+        idToNode.remove(nodeToRemove.task.getId());
     }
 }

--- a/src/com/yandex/app/service/Node.java
+++ b/src/com/yandex/app/service/Node.java
@@ -1,0 +1,13 @@
+package com.yandex.app.service;
+
+public class Node<T> {
+    public T task;
+    public Node<T> prev;
+    public Node<T> next;
+
+    public Node(Node<T> prev, T task, Node<T> next) {
+        this.prev = prev;
+        this.task = task;
+        this.next = next;
+    }
+}


### PR DESCRIPTION
Добавила класс Node.
В интерфейс HistoryManager добавила метод remove() и реализовала его в классе InMemoryHistoryManager. Переписала все методы в InMemoryHistoryManager, чтобы он работал со связным списком, добавила методы remove, removeNode, getTasks, linkLast. В классах Task, Epic, Subtask переопределила метод toString. В классе InMemoryHistoryManagerTest переписала метод add, переименовала метод saveOldTask в saveNewTask и переписала логику, добавила методы deleteTask(), removedTasksDoNotKeepOldIds(), removedSubtasksDoNotKeepOldIds(), changeFieldsBySetters().